### PR TITLE
Add code generators section in other resources with initializr and bootify

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ _A collection of awesome YouTube channels and playlists about the Spring landsca
 * [Spring I/O Conference](https://www.youtube.com/c/SpringIOConference/) - Videos of keynotes and talks from all the past editions of the Spring I/O Conference.
 * [Spring Tips](https://www.youtube.com/playlist?list=PLgGXSWYM2FpPw8rV0tZoMiJYSCiLhPnOc) - Video playlist with tips and tutorials about Spring by Josh Long.
 
+
+### Code Generators
+
+* [Spring Initializr](https://start.spring.io/) - Get the basic structure of your Spring Boot project with your config and dependencies.
+* [Bootify](https://bootify.io) - Generate Spring Boot apps with custom database and REST API.
+
 ## Contributing
 
 Contributions are very welcome!

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ _A collection of awesome YouTube channels and playlists about the Spring landsca
 * [Spring Tips](https://www.youtube.com/playlist?list=PLgGXSWYM2FpPw8rV0tZoMiJYSCiLhPnOc) - Video playlist with tips and tutorials about Spring by Josh Long.
 
 
-### Code Generators
+### Project Scaffolding
 
-* [Spring Initializr](https://start.spring.io/) - Get the basic structure of your Spring Boot project with your config and dependencies.
 * [Bootify](https://bootify.io) - Generate Spring Boot apps with custom database and REST API.
+* [Spring Initializr](https://start.spring.io/) - Get the basic structure of your Spring Boot project with your config and dependencies.
 
 ## Contributing
 


### PR DESCRIPTION
Hello,
how about adding a "code generators" section under others? Spring Initializr is a must-know for Spring Boot developers I guess, and Bootify can be useful as well if you work with a relational database.